### PR TITLE
#188838840 Refactor: Avoid installing lua-resty-string as it is included in moesifapi-lua

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN luarocks path --bin
 # Install Lua modules (including resty.core)
 RUN luarocks install --server=http://luarocks.org/manifests/moesif lua-resty-moesif && \
     luarocks install lua-resty-core && \
-    luarocks install lua-resty-string && \
     luarocks install lua-resty-jwt
 
 # Configure Nginx to use LuaJIT 2.1


### PR DESCRIPTION
Refactor: Avoid installing lua-resty-string as it is included in moesifapi-lua